### PR TITLE
Have the last pyopenssl close #53

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -26,6 +26,6 @@
 - name: Pip - pyopenssl
   pip:
     name: pyopenssl
-    version: 0.15
+    extra_args: -U
   become: true
 


### PR DESCRIPTION
### Current behaviour
When i try to vagrant up i have this error :
```
fatal: [default]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 127.0.0.1 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_5ExPcn/ansible_module_docker_image.py\", line 250, in <module>\r\n    from ansible.module_utils.docker_common import HAS_DOCKER_PY_2, HAS_DOCKER_PY_3, AnsibleDockerClient, DockerBaseClass\r\n  File \"/tmp/ansible_5ExPcn/ansible_modlib.zip/ansible/module_utils/docker_common.py\", line 36, in <module>\r\n  File \"/usr/lib/python2.7/site-packages/requests/__init__.py\", line 95, in <module>\r\n    from urllib3.contrib import pyopenssl\r\n  File \"/usr/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py\", line 46, in <module>\r\n    import OpenSSL.SSL\r\n  File \"/usr/lib64/python2.7/site-packages/OpenSSL/__init__.py\", line 8, in <module>\r\n    from OpenSSL import rand, crypto, SSL\r\n  File \"/usr/lib64/python2.7/site-packages/OpenSSL/SSL.py\", line 118, in <module>\r\n    SSL_ST_INIT = _lib.SSL_ST_INIT\r\nAttributeError: 'module' object has no attribute 'SSL_ST_INIT'\r\n", "msg": "MODULE FAILURE", "rc": 1}
```

### Expected behaviour

Have a functionnal install

### Changes proposed

-  [ ] Delete the fix version to 0.15
-  [ ] Use extra-args from pip module to install the last version of pyopenssl

### Related issues

- #53 

> **note** : Put closes #XXXX in your commit message to auto-close the issue that your PR fixes (if such).
