### PR TITLE
replaced reference of the team name to actinium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![CircleCI](https://circleci.com/gh/TheFkinCompany/allspark.svg?style=svg)](https://circleci.com/gh/TheFkinCompany/allspark)
-[![Updates](https://pyup.io/repos/github/TheFkinCompany/allspark/shield.svg)](https://pyup.io/repos/github/TheFkinCompany/allspark/)
-[![Python 3](https://pyup.io/repos/github/TheFkinCompany/allspark/python-3-shield.svg)](https://pyup.io/repos/github/TheFkinCompany/allspark/)
+[![CircleCI](https://circleci.com/gh/actiniumio/allspark.svg?style=svg)](https://circleci.com/gh/actiniumio/allspark)
+[![Updates](https://pyup.io/repos/github/actiniumio/allspark/shield.svg)](https://pyup.io/repos/github/actiniumio/allspark/)
+[![Python 3](https://pyup.io/repos/github/actiniumio/allspark/python-3-shield.svg)](https://pyup.io/repos/github/actiniumio/allspark/)
 
 # Allspark
 
-Docker based developer toolbox, see the [Documentation](https://thefkincompany.github.io/allspark) for informations.
+Docker based developer toolbox, see the [Documentation](https://docs.actinium.io/) for informations.

--- a/docs/nav/configuration.md
+++ b/docs/nav/configuration.md
@@ -42,4 +42,4 @@ allspark_traefik:
        gitlab_tag: latest
     ```
 
-    You can access the complete list of available components in the [roles/downloads/defaults/main.yml](https://github.com/TheFkinCompany/allspark/blob/master/roles/download/defaults/main.yml) file.
+    You can access the complete list of available components in the [roles/downloads/defaults/main.yml](https://github.com/actiniumio/allspark/blob/master/roles/download/defaults/main.yml) file.

--- a/docs/nav/index.md
+++ b/docs/nav/index.md
@@ -1,5 +1,5 @@
 # Allspark
 
-[![CircleCI](https://circleci.com/gh/TheFkinCompany/allspark.svg?style=svg)](https://circleci.com/gh/TheFkinCompany/allspark)
-[![Updates](https://pyup.io/repos/github/TheFkinCompany/allspark/shield.svg)](https://pyup.io/repos/github/TheFkinCompany/allspark/)
-[![Python 3](https://pyup.io/repos/github/TheFkinCompany/allspark/python-3-shield.svg)](https://pyup.io/repos/github/TheFkinCompany/allspark/)
+[![CircleCI](https://circleci.com/gh/actiniumio/allspark.svg?style=svg)](https://circleci.com/gh/actiniumio/allspark)
+[![Updates](https://pyup.io/repos/github/actiniumio/allspark/shield.svg)](https://pyup.io/repos/github/actiniumio/allspark/)
+[![Python 3](https://pyup.io/repos/github/actiniumio/allspark/python-3-shield.svg)](https://pyup.io/repos/github/actiniumio/allspark/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Allspark
 site_description: The developper toolbox.
-site_author: The fkin company
+site_author: Actinium team
 theme:
   name: 'material'
   palette:
@@ -19,7 +19,7 @@ nav:
   - Operation: operation.md
   - Troubleshooting: troubleshooting.md
 
-repo_url: https://github.com/TheFkinCompany/allspark
+repo_url: https://github.com/actiniumio/allspark
 markdown_extensions:
   # For notes and stuff: http://squidfunk.github.io/mkdocs-material/extensions/admonition/
   - admonition


### PR DESCRIPTION
### Current behaviour

> Describe here the observed behaviour of the software.

- Github references are done using the `thefkincompany` placeholder name
- Docs is hosted on `github.io` public domain.

---
### Expected behaviour

> Describe here what you expected the software to do instead.

- Github team renamed to Actinium
- Links pointing to actinium

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] Renamed organization 
-  [x] Changed Github references
-  [x] Changed docs URL

---
### Related issues

> What issue are affected by or affecting this pull request.

---
### Status

- [x] Implementation
- [x] Test coverage
- [x] Documentation
