### PR TITLE
Update SSH-Key to build docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "59:35:d6:58:31:87:ac:e6:f2:87:f3:0e:9e:8d:c2:e1"
+            - "3e:42:39:0c:71:79:a2:20:13:68:de:3a:a7:0d:a9:b5"
       - run:
           name: Install Virtualenv dependencies for Pip
           command: pip install --user virtualenv
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "59:35:d6:58:31:87:ac:e6:f2:87:f3:0e:9e:8d:c2:e1"
+            - "3e:42:39:0c:71:79:a2:20:13:68:de:3a:a7:0d:a9:b5"
       - run: pip install --user -r ./.circleci/requirements.txt
       - run: PATH=$PATH:/root/.local/bin ansible-lint install.yml -c .circleci/.ansible-lint
       - run: PATH=$PATH:/root/.local/bin ansible-lint setup.yml -c .circleci/.ansible-lint


### PR DESCRIPTION
### Current behaviour

```
ERROR: The key you are authenticating with has been marked as read only.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Exited with code 128
```
---
### Expected behaviour

Up-to-date Documentation

---
### Modifications

-  [x] Add a new SSH key
-  [x] Update Github & CircleCI
-  [x] Update .circleci/config.yml

---
### Related issues

> What issue are affected by or affecting this pull request.

- resolve #76 

---
### Status

- [x] Implementation
- [x] Test coverage
- [x] Documentation
