### PR TITLE
Fix error display on CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Actually, you need to edit `.circleci/.config.yml` if you add a main core playbo
 _e.g_:
 ```yaml
  - run: PATH=$PATH:/root/.local/bin ansible-lint mynewplaybook.yml -c .circleci/.ansible-lint
+```
 
 
 ### Docker images


### PR DESCRIPTION
### Current behaviour

Fail display on contributing look #78 

---
### Expected behaviour

Need to have a correct display on the contributing.md

![image](https://user-images.githubusercontent.com/34829865/44515633-5766f980-a6c3-11e8-95bb-a78892319c62.png)

---
### Modifications

-  [x] add ``` on Ansible Lint part

---
### Related issues

> What issue are affected by or affecting this pull request.

- resolve #78

---
### Status

- [x] Documentation
