### PR TITLE
Update Email address on circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.3
     environment:
-      - COMMIT_AUTHOR_EMAIL: "guiadco4geekhomeinside@gmail.com"
+      - COMMIT_AUTHOR_EMAIL: "bot.actinium@gmail.com"
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
### Current behaviour

I don't want to use a personnal email adress for this repository

---
### Expected behaviour

Have a service email address

---
### Modifications

-  [x] Change the email to value bot.actinium@gmail.com

---
### Status

- [x] Implementation
- [ ] Test coverage
- [x] Documentation
