### PR TITLE
Fix error docker repo file vars

### DIFF
--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -4,7 +4,7 @@ allspark_epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-late
 allspark_epel_gpg_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 allspark_redhat_docker_repo: "https://download.docker.com/linux/centos/docker-ce.repo"
 allspark_fedora_docker_repo: "https://download.docker.com/linux/fedora/docker-ce.repo"
-allspark_epel_repo_file: "/etc/yum.repos.d/docker.repo"
+allspark_docker_repo_file: "/etc/yum.repos.d/docker.repo"
 
 
 ## Debian / Ubuntu specific system configuration

--- a/roles/system/tasks/RedHat.yml
+++ b/roles/system/tasks/RedHat.yml
@@ -45,7 +45,7 @@
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Add Docker repo - Only for CentOS/RedHat"
   get_url:
     url: "{{ allspark_redhat_docker_repo }}"
-    dest: "{{ allspark_epel_repo_file }}"
+    dest: "{{ allspark_docker_repo_file }}"
   become: yes
   when:
     - ansible_distribution != "Fedora"


### PR DESCRIPTION
### Current behaviour
```
 [WARNING]: While constructing a mapping from
/home/guiadco/Documents/actiniumio/allspark/roles/system/defaults/main.yml,
line 2, column 1, found a duplicate dict key (allspark_epel_repo_file). Using
last defined value only.
```

```
TASK [system : CentOS-7 Core - Install Specific OS Release dependency] *********
task path: /home/guiadco/Documents/actiniumio/allspark/roles/system/tasks/RedHat.yml:53
fatal: [centos7]: FAILED! => {
    "reason": "Unable to retrieve file contents\nCould not find or access '/home/guiadco/Documents/actiniumio/allspark/CentOS-7.yml' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"
}
```

---
### Expected behaviour

Install Playbook OK

---
### Modifications

-  [ ] Change epel_repo_file to docker on the second vars
-  [ ] Update RedHat System PLaybook to fix the docker_repo_file vars

---
### Status

- [x] Implementation
- [x] Test coverage
- [x] Documentation