### PR TITLE
dropped bridge network for backend containers

### DIFF
--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -34,6 +34,7 @@
       - "{{ allspark_root_directory }}/data/secrets/gitlab_runner_registration_token.txt:/run/secrets/gitlab_runner_registration_token.txt"
       - "{{ allspark_root_directory }}/data/secrets/admin_password.txt:/run/secrets/admin_password.txt"
     restart_policy: always
+    purge_networks: true
     networks:
       - name: allspark
     labels:

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -19,6 +19,7 @@
     name: jenkins
     image: "{{ downloads.jenkins.image }}:{{ downloads.jenkins.tag }}"
     state: "{{ allspark_jenkins.enabled and 'started' or 'absent'}}"
+    purge_networks: true
     networks:
       - name: allspark
     env:

--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -21,6 +21,7 @@
     hostname: ldap_backend
     image: "{{ downloads.openldap.image }}:{{ downloads.openldap.tag }}"
     state: "{{ allspark_ldap.enabled and 'started' or 'absent'}}"
+    purge_networks: true
     networks:
       - name: allspark
     env:
@@ -37,6 +38,7 @@
     name: ldap_management
     image: "{{ downloads.phpldapadmin.image }}:{{ downloads.phpldapadmin.tag }}"
     state: "{{ allspark_ldap.enabled and 'started' or 'absent'}}"
+    purge_networks: true
     networks:
       - name: allspark
     env:

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -13,6 +13,7 @@
         "/var/run:/var/run:rw",
         "/:/rootfs:ro"
       ]
+    purge_networks: true
     networks:
       - name: allspark
     restart_policy: always
@@ -33,6 +34,7 @@
       - '--path.sysfs=/host/sys'
       - --collector.filesystem.ignored-mount-points
       - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs|rootfs/var/lib/docker/devicemapper|rootfs/var/lib/docker/plugins|rootfs/run/user)($$|/)"
+    purge_networks: true
     networks:
       - name: allspark
     restart_policy: always
@@ -69,6 +71,7 @@
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
+    purge_networks: true
     networks:
       - name: allspark
     restart_policy: always
@@ -100,6 +103,7 @@
     env_file: "{{ allspark_root_directory }}/config/grafana/config.monitoring"
     entrypoint: /etc/grafana/allspark_init.sh
     restart_policy: always
+    purge_networks: true
     networks:
       - name: allspark
     labels:

--- a/roles/sonarqube/tasks/main.yml
+++ b/roles/sonarqube/tasks/main.yml
@@ -12,6 +12,7 @@
     name: sonarqube
     image: "{{ downloads.sonarqube.image }}:{{ downloads.sonarqube.tag }}"
     state: "{{ allspark_sonarqube.enabled and 'started' or 'absent'}}"
+    purge_networks: true
     networks:
       - name: allspark
     volumes:

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -12,6 +12,7 @@
       - "{{ allspark_root_directory }}/data/secrets/admin_password.txt:/data/secrets/portainer-pass"
       - "/var/run/docker.sock:/var/run/docker.sock"
     command: "--admin-password-file /data/secrets/portainer-pass --no-analytics --host unix:///var/run/docker.sock"
+    purge_networks: true
     networks:
       - name: allspark
     labels:
@@ -31,6 +32,7 @@
     name: rocketchat_database
     image: "{{ downloads.rocketchat_mongodb.image }}:{{ downloads.rocketchat_mongodb.tag }}"
     state: "{{ allspark_rocketchat.enabled and 'started' or 'absent'}}"
+    purge_networks: true
     networks:
       - name: allspark
     volumes:
@@ -49,6 +51,7 @@
       ROOT_URL: "http://chat.{{ allspark_root_domain }}"
     volumes:
       - "allspark_rocketchat_avatars:/app/uploads"
+    purge_networks: true
     networks:
       - name: allspark
     labels:
@@ -171,6 +174,7 @@
       POSTGRES_PASSWORD: "{{ allspark_admin_password_mattermostdb.stdout }}"
       POSTGRES_DB: "mattermostdb"
       POSTGRES_INITDB_ARGS: "--data-checksums"
+    purge_networks: true
     networks:
       - name: allspark
     volumes:
@@ -194,6 +198,7 @@
       - "allspark_mattermost_logs:/mattermost/logs"
       - "allspark_mattermost_config:/mattermost/config"
       - "{{ allspark_root_directory }}/config/mattermost/config.json:/mattermost/config/config.json"
+    purge_networks: true
     networks:
       - name: allspark
     labels:


### PR DESCRIPTION
### Current behaviour

> Describe here the observed behaviour of the software.
All the containers have an IP address on the bridge.
---
### Expected behaviour

> Describe here what you expected the software to do instead.
The reverse proxy should be the only one on the bridge
---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] added `purge_networks` argument in the `docker_container` tasks

---
### Status

- [x] Implementation

