### PR TITLE
fix error on system playbook

### DIFF
--- a/roles/system/tasks/Debian.yml
+++ b/roles/system/tasks/Debian.yml
@@ -38,7 +38,7 @@
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Install Specific OS Release dependencies"
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
   when:
-    - ansible_distribution == "Ubuntu"
+    - ansible_distribution != "Debian"
 
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Add Docker apt key"
   apt_key:

--- a/roles/system/tasks/Debian.yml
+++ b/roles/system/tasks/Debian.yml
@@ -37,6 +37,8 @@
 
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Install Specific OS Release dependencies"
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+  when:
+    - ansible_distribution == "Ubuntu"
 
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Add Docker apt key"
   apt_key:

--- a/roles/system/tasks/RedHat.yml
+++ b/roles/system/tasks/RedHat.yml
@@ -53,7 +53,7 @@
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Install Specific OS Release dependency"
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
   when:
-    - ansible_distribution == "Fedora"
+    - ansible_distribution != "CentOS" or ansible_distribution != "RedHat"
 
 # Older versions of Docker are the same on CentOS/RedHat/Fedora
 # CentOS : https://docs.docker.com/install/linux/docker-ce/centos/

--- a/roles/system/tasks/RedHat.yml
+++ b/roles/system/tasks/RedHat.yml
@@ -52,6 +52,8 @@
 
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Install Specific OS Release dependency"
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+  when:
+    - ansible_distribution == "Fedora"
 
 # Older versions of Docker are the same on CentOS/RedHat/Fedora
 # CentOS : https://docs.docker.com/install/linux/docker-ce/centos/

--- a/roles/system/tasks/RedHat.yml
+++ b/roles/system/tasks/RedHat.yml
@@ -53,7 +53,7 @@
 - name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Install Specific OS Release dependency"
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
   when:
-    - ansible_distribution != "CentOS" or ansible_distribution != "RedHat"
+    - ansible_distribution != "CentOS" and ansible_distribution != "RedHat"
 
 # Older versions of Docker are the same on CentOS/RedHat/Fedora
 # CentOS : https://docs.docker.com/install/linux/docker-ce/centos/


### PR DESCRIPTION
### Current behaviour

```
TASK [system : CentOS-7 Core - Install Specific OS Release dependency] *********
task path: /home/guiadco/Documents/actiniumio/allspark/roles/system/tasks/RedHat.yml:53
fatal: [centos7]: FAILED! => {
    "reason": "Unable to retrieve file contents\nCould not find or access '/home/guiadco/Documents/actiniumio/allspark/CentOS-7.yml' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"
}
```

---
### Expected behaviour

```
PLAY RECAP *********************************************************************
centos7                    : ok=90   changed=45   unreachable=0    failed=0   
```

---
### Modifications

> What are the changes involved to match with the expected behaviour ?
- [ ] Add line on Redhat and Debian
```
- name: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }} {{ ansible_distribution_release }} - Install Specific OS Release dependencies"
  include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
  when:
    - ansible_distribution == "Ubuntu"
```
---
### Status

- [x] Implementation
- [x] Test coverage
