### PR TITLE
refactored multiple boxes definitions in one

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,74 +1,32 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+boxes = {
+  "centos7" => "actinium/centos7",
+  "ubuntu14" => "actinium/ubuntu14",
+  "fedoraserver28" => "actinium/fedoraserver28",
+  "fedoraatomic28" => "actinium/fedoraatomic28",
+}
+
 Vagrant.configure("2") do |config|
-  config.vm.define "centos7", primary: true do |centos7|
-    centos7.vm.box = "actinium/centos7"
-    config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 8443, host: 8443, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 2223, host: 2223, host_ip: "127.0.0.1"
-    centos7.vm.provider "virtualbox" do |vb|
-      vb.memory = "2048"
-    end
-    centos7.vm.provision "ansible" do |ansible|
-      ansible.verbose = "vvv"
-      ansible.playbook = "install.yml"
-      ansible.extra_vars = {
-        haproxy_http_port:  8080,
-        haproxy_https_port: 8443
-      }
-    end
-  end
-  config.vm.define "ubuntu14", autostart: false do |ubuntu14|
-    ubuntu14.vm.box = "actinium/ubuntu14"
-    config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 8443, host: 8443, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 2223, host: 2223, host_ip: "127.0.0.1"
-    ubuntu14.vm.provider "virtualbox" do |vb|
-      vb.memory = "2048"
-    end
-    ubuntu14.vm.provision "ansible" do |ansible|
-      ansible.verbose = "vvv"
-      ansible.playbook = "install.yml"
-      ansible.extra_vars = {
-        haproxy_http_port:  8080,
-        haproxy_https_port: 8443
-      }
-    end
-  end
-  config.vm.define "fedoraserver28", autostart: false do |fedoraserver28|
-    fedoraserver28.vm.box = "actinium/fedoraserver28"
-    config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 8443, host: 8443, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 2223, host: 2223, host_ip: "127.0.0.1"
-    fedoraserver28.vm.provider "virtualbox" do |vb|
-      vb.memory = "2048"
-    end
-    fedoraserver28.vm.provision "ansible" do |ansible|
-      ansible.verbose = "vvv"
-      ansible.playbook = "install.yml"
-      ansible.extra_vars = {
-        haproxy_http_port:  8080,
-        haproxy_https_port: 8443
-      }
-    end
-  end
-  config.vm.define "fedoraatomic28", autostart: false do |fedoraatomic28|
-    fedoraatomic28.vm.box = "actinium/fedoraatomic28"
-    config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 8443, host: 8443, host_ip: "127.0.0.1"
-    config.vm.network "forwarded_port", guest: 2223, host: 2223, host_ip: "127.0.0.1"
-    fedoraatomic28.vm.provider "virtualbox" do |vb|
-      vb.memory = "2048"
-    end
-    fedoraatomic28.vm.provision "ansible" do |ansible|
-      ansible.become = true
-      ansible.verbose = "vvv"
-      ansible.playbook = "install.yml"
-      ansible.extra_vars = {
-        haproxy_http_port:  8080,
-        haproxy_https_port: 8443
-      }
+  boxes.keys.each do |box|
+    config.vm.define "#{box}", primary: true do |b|
+      config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
+      config.vm.network "forwarded_port", guest: 8443, host: 8443, host_ip: "127.0.0.1"
+      config.vm.network "forwarded_port", guest: 2223, host: 2223, host_ip: "127.0.0.1"
+
+      b.vm.box = boxes[box]
+      b.vm.provider "virtualbox" do |vb|
+        vb.memory = "2048"
+      end
+      b.vm.provision "ansible" do |ansible|
+        ansible.verbose = "vvv"
+        ansible.playbook = "install.yml"
+        ansible.extra_vars = {
+          haproxy_http_port:  8080,
+          haproxy_https_port: 8443
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
### Current behaviour

One copy paste of the vm configuration for each box in the Vagrantfile

---
### Expected behaviour

One configuration definition, applied to the different boxes.

---
### Modifications

- [x] Define boxes in a separated object
- [x] loop over the boxes to define the virtual machines


---
### Status

- [x] Implementation
- [x] Test coverage

