### PR TITLE
Fix Right

### DIFF
--- a/docs/nav/configuration.md
+++ b/docs/nav/configuration.md
@@ -1,5 +1,15 @@
 # Configuration
 
+## Hosts
+- Edit the file `hosts` to fit with
+your needs, like:
+  - Define the ansible_user (In this example we use a account named admin_devops)
+
+```yaml
+[all]
+localhost ansible_connection=ssh ansible_user=admin_devops
+```
+
 ## Group_vars
 - Edit the file `group_vars/all.yml` to fit with
 your needs, like:

--- a/docs/nav/install.md
+++ b/docs/nav/install.md
@@ -4,6 +4,17 @@
 
 ### On the allspark machine
 - Docker ( tested with version 18.06.0 )
+- Copy your ssh key to tyhe remote server (with an empty passphrase)
+
+## Generate SSH Key
+```bash
+$ ssh-keygen
+```
+
+## Copy SSH Key
+```bash
+ssh-copy-id -i ~/.ssh/id_rsa admin_devops@localhost
+```
 
 ### On the control machine
 - Ansible ( tested with version 2.5.5 )
@@ -43,7 +54,7 @@ ansible-playbook -i hosts release.yml
 
 ```ini tab="hosts"
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=ssh ansible_user=admin_devops
 ```
 
 it will generate a `.tar.gz` file at `allspark_release_destination`.
@@ -63,7 +74,7 @@ ansible-playbook -i hosts install.yml
 
 ```ini tab="hosts"
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=ssh ansible_user=admin_devops
 ```
 
 !!! warning

--- a/hosts
+++ b/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=ssh ansible_user=admin_devops

--- a/roles/local_datas/tasks/main.yml
+++ b/roles/local_datas/tasks/main.yml
@@ -2,6 +2,9 @@
   file:
     state: directory
     path: "{{ allspark_root_directory }}/{{item}}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 750
   with_items:
     - config
     - data

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -2,6 +2,26 @@
   docker_volume:
     name: "allspark_portainer_data"
 
+- name: Generate portainer password
+  template:
+    src: "{{ allspark_root_directory }}/data/secrets/admin_password.txt"
+    dest: "{{ allspark_root_directory }}/config/mattermost/portainer_password.txt"
+  register: portainer_password
+
+## Portainer change the contents of it's configuration file at runtime
+## To avoid indepotency break using only the template module on this file,
+## we first copy it to config_i.json and then override runtime config
+## only if this task changed.
+- name: Copy Portainer runtime password
+  copy:
+    remote_src: yes
+    src: "{{ allspark_root_directory }}/config/mattermost/portainer_password_i.txt"
+    dest: "{{ allspark_root_directory }}/config/mattermost/portainer_password.txt"
+    owner: 1000
+    group: 1000
+  become: true
+  when: portainer_password is changed
+
 - name: Setup Portainer as infra service
   docker_container:
     name: portainer
@@ -9,7 +29,7 @@
     state: "{{ allspark_portainer.enabled and 'started' or 'absent'}}"
     volumes:
       - "allspark_portainer_data:/data"
-      - "{{ allspark_root_directory }}/data/secrets/admin_password.txt:/data/secrets/portainer-pass"
+      - "{{ allspark_root_directory }}/data/secrets/portainer_password.txt:/data/secrets/portainer-pass"
       - "/var/run/docker.sock:/var/run/docker.sock"
     command: "--admin-password-file /data/secrets/portainer-pass --no-analytics --host unix:///var/run/docker.sock"
     purge_networks: true


### PR DESCRIPTION
### Current behaviour

When i have a user with the wheel group as recommand by the developpers team, i incounter some right's problem, and i don't have any password on apps

---
### Expected behaviour

Have a fresh allspark working on my server

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [ ] Change the ansible connection local to ssh to force shell reconnection
-  [ ] Fix owner/group on the local data use by allspark to setup
-  [ ] Fix uid on the portainer password file so you can use user with id different from the standard (1000)

---
### Status

- [x] Implementation
- [x] Test coverage
- [x] Documentation
