### PR TITLE
Feature/ssl certificates import

### DIFF
--- a/docs/nav/configuration.md
+++ b/docs/nav/configuration.md
@@ -7,23 +7,31 @@ your needs, like:
     (each component will be exposed as a subdomain).
   - The `allspark_docker_version` to choose the docker version you want.
   - Enable or disable component using their `enabled` boolean toggle.
-  - Enable or disable certificates option using their `enable` boolean Toggle.
-    - You can set all you want for the self-signed use.
 
-```
+```yaml
 allspark_monitoring:
   enabled: true
-
-allspark_haproxy:
-  selfsigned:
-    enabled: false
-    # For example country: FR
-    country: XX
-    state: state
-    location: city
-    organisation: myteam
-    organizational_unit: myorganizational_unit
 ```
+
+### HTTPS
+
+In order to provide HTTPS, you can either :
+
+- Enable self signed certificates by activating the `allspark_haproxy.ssl.enabled` and `allspark_haproxy.ssl.selfsigned.enabled` flags.
+- Import a certificate from your control machine : enable `allspark_haproxy.ssl.enabled`,
+set the `allspark_haproxy.ssl.certificates_directory` variable to a folder on the control machine
+containing PEM certificates named like their endpoint (e.g: `infra.allspark.localhost.pem`)
+
+You can also do a mix of both, imported certificates will be picked over generated ones,
+allowing you to import certificates for some of the endpoints and let Allspark generate
+the missing ones.
+
+!!! note
+    For wildcard and UCC certificates signing multiple domains, simply copy the file (or create a symbolic link pointing to it) to mirror the new endpoint
+    e.g:
+    ```sh
+    cp infra.allspark.localhost.pem chat.allspark.localhost
+    ```
 
 ## Downloads
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -16,14 +16,25 @@ allspark_monitoring:
   enabled: true
 
 allspark_haproxy:
-  selfsigned:
+  ssl:
     enabled: false
-    # For example country: FR
-    country: XX
-    state: state
-    location: city
-    organisation: myteam
-    organizational_unit: myorganizational_unit
+    # If SSL is enabled, you can set the directory from which
+    # endpoints certificates will be imported with this variable.
+    # Files in the local directory should be PEM formatted certificates
+    # named like their endpoint (e.g: `infra.allspark.localhost.pem`)
+    certificates_directory:
+    # If selfsigned certificates are enabled, any certificate missing
+    # for an endpoint will be created on the fly.
+    # If selfsigned is disabled and a certificate is missing, the
+    # install won't be able to complete successfully.
+    selfsigned:
+      enabled: false
+      # For example country: FR
+      country: XX
+      state: state
+      location: city
+      organisation: myteam
+      organizational_unit: myorganizational_unit
 
 
 allspark_rocketchat:

--- a/roles/haproxy/tasks/certificates.yml
+++ b/roles/haproxy/tasks/certificates.yml
@@ -1,3 +1,14 @@
+- name: "HAProxy - Stat local user provided certificate directory"
+  stat: path="{{ allspark_haproxy.ssl.certificates_directory }}"
+  delegate_to: localhost
+  register: local_cert_dir
+
+# Check that certificates_directory is a valid directory on the control machine.
+- name: "HAProxy - Preflight checks"
+  fail: msg="allspark_haproxy.ssl.certificates_directory is invalid and self signed certificates are disabled."
+  when: (local_cert_dir.stat.isdir is not defined or not local_cert_dir.stat.isdir) and not allspark_haproxy.ssl.selfsigned.enabled
+
+
 - name: "HAProxy - Certificates directory"
   file:
     state: directory
@@ -6,6 +17,8 @@
     - "{{ allspark_root_directory }}/data/secrets/haproxy/private_keys/"
     - "{{ allspark_root_directory }}/data/secrets/haproxy/csrs/"
     - "{{ allspark_root_directory }}/data/secrets/haproxy/certificates/"
+    - "{{ allspark_root_directory }}/data/secrets/haproxy/certificates/generated"
+    - "{{ allspark_root_directory }}/data/secrets/haproxy/certificates/imported"
     - "{{ allspark_root_directory }}/data/ssl/certificates"
 
 - name: "HAProxy - Certificate authority private key [RSA 2048]"
@@ -14,6 +27,7 @@
     type: RSA
     size: 2048
   register: priv
+  when: allspark_haproxy.ssl.selfsigned.enabled
 
 - name: "HAProxy - Certificate authority CSR"
   openssl_csr:
@@ -25,11 +39,13 @@
     - digitalSignature
     - keyCertSign
   register: csr
+  when: allspark_haproxy.ssl.selfsigned.enabled
 
 - name: "HAProxy - Certificate status"
   stat: path="{{ allspark_root_directory}}/data/ssl/certificates/ca.crt"
   changed_when: false
   register: crt_file
+  when: allspark_haproxy.ssl.selfsigned.enabled
 
 - name: "HAProxy - Certificate"
   openssl_certificate:
@@ -37,8 +53,8 @@
     privatekey_path: "{{ allspark_root_directory }}/data/secrets/haproxy/private_keys/ca.key"
     csr_path: "{{ allspark_root_directory }}/data/secrets/haproxy/csrs/ca.csr"
     provider: selfsigned
-  when: not crt_file.stat.exists or priv is changed or csr is changed
   register: cert
+  when: allspark_haproxy.ssl.selfsigned.enabled and not crt_file.stat.exists or priv is changed or csr is changed
 
 - name: "Endpoints certificates"
   include_tasks: "selfsign_domain.yml"

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -5,8 +5,7 @@
 
 - name: "HAProxy - Certificates"
   include_tasks: "certificates.yml"
-  when: allspark_haproxy.selfsigned.enabled
-
+  when: allspark_haproxy.ssl.enabled
 
 - name: "HAProxy - Configuration"
   template:
@@ -24,7 +23,7 @@
     volumes: >-
       [
         "{{ allspark_root_directory }}/config/haproxy/haproxy.cfg:/etc/haproxy.cfg",
-        {% if allspark_haproxy.selfsigned.enabled %}
+        {% if allspark_haproxy.ssl.enabled %}
         "{{ allspark_root_directory }}/config/haproxy/crt-list.txt:/etc/ssl/crt-list.txt",
         {% for domain in haproxy_endpoints %}
         "{{ allspark_root_directory }}/data/secrets/haproxy/certificates/{{ domain.host }}.combined.pem:/etc/ssl/{{ domain.host }}.pem",
@@ -34,7 +33,7 @@
     ports: >-
       [
         "{{ haproxy_http_port }}:{{ haproxy_http_port }}",
-        {% if allspark_haproxy.selfsigned.enabled %}
+        {% if allspark_haproxy.ssl.enabled %}
         "{{ haproxy_https_port }}:{{ haproxy_https_port }}",
         {% endif %}
         {% for domain in haproxy_endpoints %}

--- a/roles/haproxy/tasks/selfsign_domain.yml
+++ b/roles/haproxy/tasks/selfsign_domain.yml
@@ -1,20 +1,39 @@
+- name: "{{ item.name }} - Stat local user provided certificate"
+  stat: path="{{ allspark_haproxy.ssl.certificates_directory }}/{{ item.host }}.pem"
+  changed_when: false
+  delegate_to: localhost
+  register: local_cert_file
+
+- name: "{{ item.name }} - Import certificate"
+  copy:
+    src: "{{ allspark_haproxy.ssl.certificates_directory }}/{{ item.host }}.pem"
+    dest: "{{ allspark_root_directory }}/data/secrets/haproxy/certificates/imported/{{ item.host }}.combined.pem"
+  when: local_cert_file.stat.exists
+
+- name: "{{ item.name }} - Stat remote user provided certificate"
+  changed_when: false
+  stat: path="{{ allspark_root_directory }}/data/secrets/haproxy/certificates/imported/{{ item.host }}.combined.pem"
+  register: remote_cert_file
+
 - name: "{{ item.name }} - Private key [RSA 2048]"
   openssl_privatekey:
     path: "{{ allspark_root_directory }}/data/secrets/haproxy/private_keys/{{ item.host }}.key"
     type: RSA
     size: 2048
   register: priv
+  when: not remote_cert_file.stat.exists
+
 
 - name: "{{ item.name }} - CSR"
   openssl_csr:
     path: "{{ allspark_root_directory }}/data/secrets/haproxy/csrs/{{ item.host }}.csr"
     privatekey_path: "{{ allspark_root_directory }}/data/secrets/haproxy/private_keys/{{ item.host }}.key"
     common_name: "{{ item.host }}"
-    country_name: "{{ allspark_haproxy.selfsigned.country }}"
-    state_or_province_name: "{{ allspark_haproxy.selfsigned.state }}"
-    locality_name: "{{ allspark_haproxy.selfsigned.location }}"
-    organization_name: "{{ allspark_haproxy.selfsigned.organisation }}"
-    organizational_unit_name: "{{ allspark_haproxy.selfsigned.organizational_unit }}"
+    country_name: "{{ allspark_haproxy.ssl.selfsigned.country }}"
+    state_or_province_name: "{{ allspark_haproxy.ssl.selfsigned.state }}"
+    locality_name: "{{ allspark_haproxy.ssl.selfsigned.location }}"
+    organization_name: "{{ allspark_haproxy.ssl.selfsigned.organisation }}"
+    organizational_unit_name: "{{ allspark_haproxy.ssl.selfsigned.organizational_unit }}"
     subject_alt_name: "DNS:{{ item.host }}"
     key_usage:
     - keyAgreement
@@ -22,13 +41,15 @@
     - digitalSignature
     - nonRepudiation
   register: csr
+  when: not remote_cert_file.stat.exists
 
-- name: "{{ item.name }} Certificate status"
+- name: "{{ item.name }} - Certificate status"
   stat: path="{{ allspark_root_directory}}/data/ssl/certificates/{{ item.host }}.crt"
   changed_when: false
   register: crt_file
+  when: not remote_cert_file.stat.exists
 
-- name: "{{ item.name }} Certificate"
+- name: "{{ item.name }} - Certificate"
   shell: >-
     openssl x509 -req \
       -in {{ allspark_root_directory }}/data/secrets/haproxy/csrs/{{ item.host }}.csr \
@@ -38,19 +59,25 @@
       -out {{ allspark_root_directory }}/data/ssl/certificates/{{ item.host }}.crt \
       -days 1825 \
       -sha256
-  when: not crt_file.stat.exists or priv is changed or csr is changed
   register: cert
+  when: not remote_cert_file.stat.exists and (not crt_file.stat.exists or priv is changed or csr is changed)
 
-- name: "{{ item.name }} Combined certificate status"
+- name: "{{ item.name }} - Combined certificate status"
   stat: path="{{ allspark_root_directory}}/data/secrets/haproxy/certificates/{{ item.host }}.combined.pem"
   changed_when: false
   register: combined_file
 
-- name: "{{ item.name }} Combined certificate"
+- name: "{{ item.name }} - Generate combined certificate"
   shell: >-
     cat
     {{ allspark_root_directory }}/data/secrets/haproxy/private_keys/{{ item.host }}.key
     {{ allspark_root_directory}}/data/ssl/certificates/{{ item.host }}.crt
     {{ allspark_root_directory }}/data/ssl/certificates/ca.crt
-    > {{ allspark_root_directory}}/data/secrets/haproxy/certificates/{{ item.host }}.combined.pem
-  when: not combined_file.stat.exists or priv is changed or cert is changed
+    > {{ allspark_root_directory}}/data/secrets/haproxy/certificates/generated/{{ item.host }}.combined.pem
+  when: not remote_cert_file.stat.exists and (not combined_file.stat.exists or priv is changed or cert is changed)
+
+- name: "{{ item.name }} - Certificate symlink"
+  file:
+    src: "{%- if remote_cert_file.stat.exists -%}imported{%- else -%}generated{%- endif -%}/{{ item.host }}.combined.pem"
+    dest: "{{ allspark_root_directory}}/data/secrets/haproxy/certificates/{{ item.host }}.combined.pem"
+    state: link

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -4,7 +4,7 @@
 global
   log         /dev/log local0 debug
   maxconn     4000
-  {% if allspark_haproxy.selfsigned.enabled -%}
+  {% if allspark_haproxy.ssl.enabled -%}
   ca-base /etc/ssl
   crt-base /etc/ssl
   tune.ssl.default-dh-param 2048
@@ -36,7 +36,7 @@ backend           {{ item.name }}-{{ backend.mode }}
   mode            {{ backend.mode }}
   balance         roundrobin
 
-{% if backend.mode == "http" and allspark_haproxy.selfsigned.enabled %}
+{% if backend.mode == "http" and allspark_haproxy.ssl.enabled %}
   http-response   replace-value Location ^http://(.*)$ https://\1
   redirect        scheme https if !{ ssl_fc }
 {% endif %}
@@ -53,7 +53,7 @@ frontend http-in
 
   bind            :{{ haproxy_http_port }}
   log             127.0.0.1 local0 debug
-{% if allspark_haproxy.selfsigned.enabled %}
+{% if allspark_haproxy.ssl.enabled %}
   acl             is_http dst_port {{ haproxy_http_port }}
   http-request    replace-value Host (.*):{{ haproxy_http_port }} \1 if is_http
   http-request    redirect location https://%[req.hdr(Host)]:{{ haproxy_https_port }}%[capture.req.uri] if is_http
@@ -71,7 +71,7 @@ frontend http-in
 {% endif %}
 
 
-{% if allspark_haproxy.selfsigned.enabled %}
+{% if allspark_haproxy.ssl.enabled %}
 frontend https-in
   mode            http
   option          forwardfor


### PR DESCRIPTION
### Current behaviour

Certificate can either be disabled or self signed
---
### Expected behaviour

As a developer, i need the capability to import certificates from an external source into Allspark.

---
### Modifications

- New configuration variable : `allspark_haproxy.ssl.certificates_directory`, if filled, Allspark installer will look for certificates with the appropriate naming in this directory before generating new ones.
- Imported certificates have an higher precedency than generated ones.

---
### Status

- [x] Implementation
- [x] Documentation
