### PR TITLE
Hotfix/backup restore

### DIFF
--- a/backup.yml
+++ b/backup.yml
@@ -1,4 +1,5 @@
 - name: Package an Allspark instance to a release
   hosts: all
   roles:
+    - { role: download, tags: [ "download", "prepare" ] }
     - { role: backup, allspark_operation: 'backup' }

--- a/backup.yml
+++ b/backup.yml
@@ -1,5 +1,5 @@
 - name: Package an Allspark instance to a release
   hosts: all
   roles:
-    - { role: download, tags: [ "download", "prepare" ] }
+    - download
     - { role: backup, allspark_operation: 'backup' }

--- a/restore.yml
+++ b/restore.yml
@@ -1,4 +1,5 @@
 - name: Restore an instance Allspark from release
   hosts: all
   roles:
+    - { role: download, tags: [ "download", "prepare" ] }
     - { role: backup, allspark_operation: 'restore', allspark_restore_dry_run: false }

--- a/restore.yml
+++ b/restore.yml
@@ -1,5 +1,5 @@
 - name: Restore an instance Allspark from release
   hosts: all
   roles:
-    - { role: download, tags: [ "download", "prepare" ] }
+    - download
     - { role: backup, allspark_operation: 'restore', allspark_restore_dry_run: false }

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -20,7 +20,7 @@
     - "{{ volumes_list.stdout_lines }}"
 
 - name: "[Backup] Get docker container list"
-  shell: docker ps -q --filter label=managedby=allspark | xargs -n 1 docker inspect --format \{\{' .Name '\}\} | sed 's/\// /' | tr -d '\r\n'
+  shell: docker ps -q --filter label=heritage=allspark | xargs -n 1 docker inspect --format \{\{' .Name '\}\} | sed 's/\// /' | tr -d '\r\n'
   register: names_list
   changed_when: false
 
@@ -42,7 +42,7 @@
       VOLUMERIZE_CONTAINERS: "{{ names_list.stdout }}"
     restart_policy: no
     command: >-
-      volumerize --
+      backup --
         {% if allspark_operation == 'restore' %}
           restore
           {% if allspark_restore_dry_run %}


### PR DESCRIPTION
### Current behaviour

There is no downloads roles to use that vars
```image: "{{ downloads.volumerize.image }}:{{ downloads.volumerize.tag }}"```

No application found because the label is heritage not managedby
```shell: docker ps -q --filter label=managedby=allspark | xargs -n 1 docker inspect --format \{\{' .Name '\}\} | sed 's/\// /' | tr -d '\r\n'```

When you change that you can launch the backup playbook but the backup folder is empty.

---
### Expected behaviour

have a full backup:
```
-rw------- 1 root root 209690599 Sep 17 23:50 duplicity-full.20180917T215001Z.vol1.difftar.gz
-rw------- 1 root root 209689092 Sep 17 23:50 duplicity-full.20180917T215001Z.vol2.difftar.gz
-rw------- 1 root root 209685599 Sep 17 23:50 duplicity-full.20180917T215001Z.vol3.difftar.gz
-rw------- 1 root root 209656537 Sep 17 23:50 duplicity-full.20180917T215001Z.vol4.difftar.gz
```

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

- [x] add the downloads roles only to test the same group_vars as the original, if i try to pull a images so you can identify the change on the allspark configuration
- [x] change the command part to use the name of the container as explain on the volumerize's README
- [x] change the label used to get docker container list

---
### Related issues

> What issue are affected by or affecting this pull request.

- resolve #103 
---
### Status

- [x] Implementation
- [x] Test coverage
