### PR TITLE
Fix Configuration for Mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,8 @@ markdown_extensions:
 
   - pymdownx.superfences
   - pymdownx.arithmatex
-  - pymdownx.betterem(smart_enable=all)
+  - pymdownx.betterem:
+      smart_enable: all
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.emoji:
@@ -37,5 +38,6 @@ markdown_extensions:
   - pymdownx.magiclink
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.tasklist(custom_checkbox=true)
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.tilde


### PR DESCRIPTION
Mkdocs Material change is structure

### Current behaviour

```
Building docs
ERROR   -  Config value: 'markdown_extensions'. Error: Failed loading extension "pymdownx.betterem(smart_enable=all)". 

Aborted with 1 Configuration Errors!
+ mv 'doc/*' out/
mv: cannot stat ‘doc/*’: No such file or directory
Exited with code 1
```

---
### Expected behaviour

```
Building docs
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/circleci/project/doc 
+ mv doc/404.html doc/architecture doc/assets doc/configuration doc/index.html doc/install doc/operation doc/roadmap doc/search doc/sitemap.xml doc/sitemap.xml.gz doc/troubleshooting out/
+ rm -rf doc
+ exit 0
```

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] Update MkDocs configuration files

---
### Status

- [x] Implementation
- [x] Test coverage
