### PR TITLE
Segregated database network

### DIFF
--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -133,6 +133,10 @@
     state: directory
     path: "{{ allspark_root_directory }}/config/mattermost"
 
+- name: MatterMost database network
+  docker_network:
+    name: allspark_mattermost_database
+
 - name: Generate Mattermost config
   template:
     src: templates/config.json.j2
@@ -176,7 +180,7 @@
       POSTGRES_INITDB_ARGS: "--data-checksums"
     purge_networks: true
     networks:
-      - name: allspark
+      - name: allspark_mattermost_database
     volumes:
       - "allspark_mattermost_postgres_data:/var/lib/postgresql/data"
     restart_policy: always
@@ -201,6 +205,7 @@
     purge_networks: true
     networks:
       - name: allspark
+      - name: allspark_mattermost_database
     labels:
       "heritage": "allspark"
     restart_policy: always


### PR DESCRIPTION
### Current behaviour

The database for Mattermost is on the same docker network as the rest of the stack. This could allow an intruder to access private messages from the Gitlab container (as it has the postgres client installed).

---
### Expected behaviour

Database is only reachable from the Mattermost container

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

- [x] Moved the mattermost_database container to a separated docker_network
- [x] Bound the mattermost container to both the `allspark` and the `allspark_mattermost_database` network.

---
### Status

- [x] Implementation
