### PR TITLE
Update CircleCI Conf to Have a Security Bench Report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,15 @@ jobs:
           name: Run Allspark Playbook with verbose mode
           command: ansible-playbook -i hosts install.yml -vvv
       - run:
+          name: Launch Docker Security Bench
+          command: docker run -it --net host --pid host --userns host --cap-add audit_control \
+            -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
+            -v /var/lib:/var/lib \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /usr/lib/systemd:/usr/lib/systemd \
+            -v /etc:/etc --label docker_bench_security \
+            docker/docker-bench-security
+      - run:
           name: See your container's install
           command: docker ps -a
       - run:


### PR DESCRIPTION
### Current behaviour

look that site [here](https://hub.docker.com/r/docker/docker-bench-security/)

---
### Expected behaviour

![image](https://user-images.githubusercontent.com/34829865/46814046-e39db080-cd45-11e8-88d2-dd57bfbf2a81.png)


---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] Add security bench container to the circleci config

---
### Status

- [x] Test coverage
