### PR TITLE
Feature/benchsecu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,12 +71,12 @@ jobs:
           command: ansible-playbook -i hosts install.yml -vvv
       - run:
           name: Launch Docker Security Bench
-          command: docker run -it --net host --pid host --userns host --cap-add audit_control \
-            -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
-            -v /var/lib:/var/lib \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -v /usr/lib/systemd:/usr/lib/systemd \
-            -v /etc:/etc --label docker_bench_security \
+          command: docker run -it --net host --pid host --userns host --cap-add audit_control
+            -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST
+            -v /var/lib:/var/lib
+            -v /var/run/docker.sock:/var/run/docker.sock
+            -v /etc/init.d:/etc/init.d
+            -v /etc:/etc --label docker_bench_security
             docker/docker-bench-security
       - run:
           name: See your container's install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock
             -v /etc/init.d:/etc/init.d
             -v /etc:/etc --label docker_bench_security
-            docker/docker-bench-security
+            docker/docker-bench-security -e check_1,check_4_9,check_5_1,check_5_2,check_7
       - run:
           name: See your container's install
           command: docker ps -a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,15 @@ jobs:
           name: Run Allspark Playbook with verbose mode
           command: ansible-playbook -i hosts install.yml -vvv
       - run:
+          name: Launch Docker Security Bench
+          command: docker run -it --net host --pid host --userns host --cap-add audit_control \
+            -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
+            -v /var/lib:/var/lib \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /usr/lib/systemd:/usr/lib/systemd \
+            -v /etc:/etc --label docker_bench_security \
+            docker/docker-bench-security
+      - run:
           name: See your container's install
           command: docker ps -a
       - run:


### PR DESCRIPTION
### Current behaviour

There is not security bench

---
### Expected behaviour
look that site [here](https://hub.docker.com/r/docker/docker-bench-security/)

![image](https://user-images.githubusercontent.com/34829865/46814046-e39db080-cd45-11e8-88d2-dd57bfbf2a81.png)


---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] Add security bench container to the circleci config

---
### Status

- [x] Test coverage