### PR TITLE
Placeholder receiver for alertmanager

### DIFF
--- a/roles/monitoring/templates/alertmanager.yml.j2
+++ b/roles/monitoring/templates/alertmanager.yml.j2
@@ -1,6 +1,11 @@
 global:
   resolve_timeout: 5m
 
-route: {}
-receivers: []
+route:
+  receiver: default
+
+receivers:
+  - name: default
+    email_configs:
+      from: alerts@{{ allspark_root_domain }}
 inhibit_rules: []


### PR DESCRIPTION
### Current behaviour

Alertmanager bootloop because it needs a receiver to be configured to start, but there is none in the current default configuration.

---
### Expected behaviour

Alertmanager boot correctly

---
### Modifications

- [x] Placeholder receiver

---
### Related issues

- resolve #124 

---
### Status

- [x] Implementation
- [ ] Test coverage
