### PR TITLE
Gitlab runners integration

### DIFF
--- a/roles/gitlab/files/start_runner.sh
+++ b/roles/gitlab/files/start_runner.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+true
+while [ $? -eq 0 ]
+do
+/usr/bin/gitlab-runner unregister --name Allspark
+done
+
+/usr/bin/gitlab-runner register \
+  --non-interactive \
+  --name "Allspark" \
+  --url "http://gitlab" \
+  --registration-token "$REGISTRATION_TOKEN" \
+  --executor "docker" \
+  --docker-image "$DEFAULT_RUNNER_IMAGE" \
+  --tag-list "docker" \
+  --run-untagged \
+  --locked="false" \
+&& /usr/bin/gitlab-runner \
+  run \
+  --user=gitlab-runner \
+  --working-directory=/home/gitlab-runner

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -3,17 +3,23 @@
   register: gitlab_runner_registration_token_file
   when: allspark_gitlab.enabled
 
-- name: Generate runner token
+- name: Runner token
   shell: "echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c26) > {{ allspark_root_directory}}/data/secrets/gitlab_runner_registration_token.txt"
   when: allspark_gitlab.enabled and not gitlab_runner_registration_token_file.stat.exists
 
-- name: Generate Gitlab config
-  template:
-    src: templates/gitlab.rb.j2
-    dest: "{{ allspark_root_directory }}/config/gitlab.rb"
+- name: Gitlab config directory
+  file:
+    state: directory
+    path: "{{ allspark_root_directory }}/config/gitlab"
   when: allspark_gitlab.enabled
 
-- name: Create Gitlab volumes
+- name: Gitlab config
+  template:
+    src: templates/gitlab.rb.j2
+    dest: "{{ allspark_root_directory }}/config/gitlab/gitlab.rb"
+  when: allspark_gitlab.enabled
+
+- name: Gitlab volumes
   docker_volume:
     name: "allspark_{{ item }}"
   with_items:
@@ -21,7 +27,11 @@
     - gitlab_config
   when: allspark_gitlab.enabled
 
-- name: Setup Gitlab
+- name: Runner network
+  docker_network:
+    name: allspark_gitlab_runner
+
+- name: Gitlab
   docker_container:
     name: gitlab
     state: "{{ allspark_gitlab.enabled and 'started' or 'absent'}}"
@@ -37,5 +47,9 @@
     purge_networks: true
     networks:
       - name: allspark
+      - name: allspark_gitlab_runner
     labels:
       "heritage": "allspark"
+
+- include_tasks: runner.yml
+  when: allspark_gitlab.enabled and allspark_gitlab.with_runner

--- a/roles/gitlab/tasks/runner.yml
+++ b/roles/gitlab/tasks/runner.yml
@@ -1,0 +1,39 @@
+- name: Register runner token
+  shell: "cat {{ allspark_root_directory}}/data/secrets/gitlab_runner_registration_token.txt"
+  register: gitlab_runner_token
+  changed_when: false
+  tags:
+  - skip_ansible_lint
+  when: allspark_gitlab.with_runner
+
+- name: Gitlab runner volume
+  docker_volume:
+    name: allspark_gitlab_runner
+
+- name: Runner boot script
+  copy:
+    src: ./files/start_runner.sh
+    dest: "{{ allspark_root_directory }}/config/gitlab/start_runner.sh"
+
+- name: Setup Gitlab Runner
+  docker_container:
+    name: gitlab_runner
+    state: "{{ allspark_gitlab.enabled and allspark_gitlab.with_runner and 'started' or 'absent'}}"
+    image: "{{ downloads.gitlab_runner.image }}:{{ downloads.gitlab_runner.tag }}"
+    hostname: "gitlab_runner.{{ allspark_root_domain }}"
+    volumes:
+      - "allspark_gitlab_runner:/etc/gitlab-runner"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "{{ allspark_root_directory }}/data/secrets/gitlab_runner_registration_token.txt:/run/secrets/gitlab_runner_registration_token.txt"
+      - "{{ allspark_root_directory }}/config/gitlab/start_runner.sh:/start_runner.sh"
+    env:
+      REGISTRATION_TOKEN: "{{ gitlab_runner_token.stdout }}"
+      DEFAULT_RUNNER_IMAGE: "{{ centos_image }}:{{ centos_tag }}"
+    command: /start_runner.sh
+    entrypoint: /bin/sh
+    restart_policy: always
+    purge_networks: true
+    networks:
+      - name: allspark_gitlab_runner
+    labels:
+      "heritage": "allspark"


### PR DESCRIPTION
### Current behaviour

Option was present in the configuration to enable a gitlab runner (`gitlab.with_runner` variable), but has no effect on the deployment.

---
### Expected behaviour

- Gitlab runner is deployed alongside gitlab
- Gitlab runner register itself on Gitlab
- Gitlab Runner use docker executor

---
### Remaining issues

- HTTPS verification

```
Health check error:
ContainerStart: Error response from daemon: Cannot link to a non running container: /runner-98790123-project-1-concurrent-0-docker-0 AS /runner-98790123-project-1-concurrent-0-docker-0-wait-for-service/service (executor_docker.go:1307:0s)

Service container logs:
2018-10-17T14:00:33.172004930Z mount: permission denied (are you root?)
2018-10-17T14:00:33.172803383Z Could not mount /sys/kernel/security.
2018-10-17T14:00:33.172820964Z AppArmor detection and --privileged mode might break.
2018-10-17T14:00:33.207574807Z mount: permission denied (are you root?)
```
- Needs to download some images to be usable (e.g: `docker:stable-git`), we might want to integrate them to the download role for offline instances.