### PR TITLE
Hotfix/gitlab migration

### DIFF
--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -2,24 +2,24 @@
 handlers:
   - name: change_gitlab_root_password
     command: |
-docker exec -it gitlab bash -c '
-set -xe;
-cat | gitlab-rails console production << EOF
-  user = User.where(id: 1).first;
-  user.password = File.read("/run/secrets/admin_password.txt").strip;
-  user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
-EOF
-'
+      docker exec -it gitlab bash -c '
+      set -xe;
+      cat | gitlab-rails console production << EOF
+        user = User.where(id: 1).first;
+        user.password = File.read("/run/secrets/admin_password.txt").strip;
+        user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
+      EOF
+      '
   - name: reconfigure_gitlab
     command: >-
-docker exec -it gitlab bash -c '
-set -xe;
-gitlab-ctl reconfigure;
-'
+      docker exec -it gitlab bash -c '
+      set -xe;
+      gitlab-ctl reconfigure;
+      '
 
   - name: migrate_gitlab
     command: >-
-docker exec -it gitlab bash -c '
-set -xe;
-gitlab-rake db:migrate;
-'
+      docker exec -it gitlab bash -c '
+      set -xe;
+      gitlab-rake db:migrate;
+      '

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -1,25 +1,24 @@
 ---
-handlers:
-  - name: change_gitlab_root_password
-    command: |
-      docker exec -it gitlab bash -c '
-      set -xe;
-      cat | gitlab-rails console production << EOF
-        user = User.where(id: 1).first;
-        user.password = File.read("/run/secrets/admin_password.txt").strip;
-        user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
-      EOF
-      '
-  - name: reconfigure_gitlab
-    command: >-
-      docker exec -it gitlab bash -c '
-      set -xe;
-      gitlab-ctl reconfigure;
-      '
+- name: change_gitlab_root_password
+  command: |
+    docker exec -it gitlab bash -c '
+    set -xe;
+    cat | gitlab-rails console production << EOF
+      user = User.where(id: 1).first;
+      user.password = File.read("/run/secrets/admin_password.txt").strip;
+      user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
+    EOF
+    '
+- name: reconfigure_gitlab
+  command: >-
+    docker exec -it gitlab bash -c '
+    set -xe;
+    gitlab-ctl reconfigure;
+    '
 
-  - name: migrate_gitlab
-    command: >-
-      docker exec -it gitlab bash -c '
-      set -xe;
-      gitlab-rake db:migrate;
-      '
+- name: migrate_gitlab
+  command: >-
+    docker exec -it gitlab bash -c '
+    set -xe;
+    gitlab-rake db:migrate;
+    '

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -1,4 +1,29 @@
 ---
+- name: restart_gitlab
+  command: docker restart gitlab
+
+- name: reconfigure_gitlab
+  command: >-
+    docker exec -it gitlab bash -c '
+    set -xe;
+    gitlab-ctl reconfigure;
+    '
+  register: gitlab_reconfigure
+  until: gitlab_reconfigure.rc == 0
+  retries: 10
+  delay: 30
+
+- name: migrate_gitlab
+  command: >-
+    docker exec -it gitlab bash -c '
+    set -xe;
+    gitlab-rake db:migrate;
+    '
+  register: gitlab_migrate
+  until: gitlab_migrate.rc == 0
+  retries: 10
+  delay: 30
+
 - name: change_gitlab_root_password
   command: |
     docker exec -it gitlab bash -c '
@@ -7,18 +32,10 @@
       user = User.where(id: 1).first;
       user.password = File.read(\"/run/secrets/admin_password.txt\").strip;
       user.password_confirmation = File.read(\"/run/secrets/admin_password.txt\").strip;
+      user.save!
     " | gitlab-rails console production
     '
-- name: reconfigure_gitlab
-  command: >-
-    docker exec -it gitlab bash -c '
-    set -xe;
-    gitlab-ctl reconfigure;
-    '
-
-- name: migrate_gitlab
-  command: >-
-    docker exec -it gitlab bash -c '
-    set -xe;
-    gitlab-rake db:migrate;
-    '
+  register: gitlab_root_pw_change
+  until: gitlab_root_pw_change.rc == 0
+  retries: 10
+  delay: 30

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -1,0 +1,24 @@
+---
+handlers:
+  - name: change_gitlab_root_password
+    command: |
+      docker exec -it gitlab bash -c '
+set -xe;
+cat | gitlab-rails console production << EOF
+  user = User.where(id: 1).first;
+  user.password = File.read("/run/secrets/admin_password.txt").strip;
+  user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
+EOF
+      '
+  - name: reconfigure_gitlab
+    command: >-
+      docker exec -it gitlab bash -c '
+set -xe;
+gitlab-ctl reconfigure;
+      '
+  - name: migrate_gitlab
+    command: >-
+      docker exec -it gitlab bash -c '
+set -xe;
+gitlab-rake db:migrate;
+      '

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -3,11 +3,11 @@
   command: |
     docker exec -it gitlab bash -c '
     set -xe;
-    cat | gitlab-rails console production << EOF
+    echo "
       user = User.where(id: 1).first;
-      user.password = File.read("/run/secrets/admin_password.txt").strip;
-      user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
-    EOF
+      user.password = File.read(\"/run/secrets/admin_password.txt\").strip;
+      user.password_confirmation = File.read(\"/run/secrets/admin_password.txt\").strip;
+    " | gitlab-rails console production
     '
 - name: reconfigure_gitlab
   command: >-

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -2,23 +2,24 @@
 handlers:
   - name: change_gitlab_root_password
     command: |
-      docker exec -it gitlab bash -c '
+docker exec -it gitlab bash -c '
 set -xe;
 cat | gitlab-rails console production << EOF
   user = User.where(id: 1).first;
   user.password = File.read("/run/secrets/admin_password.txt").strip;
   user.password_confirmation = File.read("/run/secrets/admin_password.txt").strip;
 EOF
-      '
+'
   - name: reconfigure_gitlab
     command: >-
-      docker exec -it gitlab bash -c '
+docker exec -it gitlab bash -c '
 set -xe;
 gitlab-ctl reconfigure;
-      '
+'
+
   - name: migrate_gitlab
     command: >-
-      docker exec -it gitlab bash -c '
+docker exec -it gitlab bash -c '
 set -xe;
 gitlab-rake db:migrate;
-      '
+'

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -9,6 +9,43 @@
   notify:
     - reconfigure_gitlab
 
+- name: Gitlab data directory
+  file:
+    state: directory
+    path: "{{ allspark_root_directory }}/data/gitlab"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0740
+  become: yes
+
+- name: Test Gitlab root password hash
+  stat: path="{{ allspark_root_directory }}/data/gitlab/root_password_hash.txt"
+  register: gitlab_root_password_file
+  when: allspark_gitlab.enabled
+  changed_when: false
+
+- name: Test root password hash
+  stat:
+    path: "{{ allspark_root_directory }}/data/secrets/admin_password.txt"
+    checksum_algorithm: sha256
+  register: root_password_sha256
+  when: allspark_gitlab.enabled
+  changed_when: false
+
+- name: Load Gitlab root password hash
+  command: "cat {{ allspark_root_directory }}/data/gitlab/root_password_hash.txt"
+  changed_when: false
+  when: gitlab_root_password_file.stat.exists
+  register: gitlab_root_password_hash
+
+- name: Gitlab root password hash
+  shell: "echo {{ root_password_sha256.stat.checksum }} > {{ allspark_root_directory }}/data/gitlab/root_password_hash.txt"
+  when: allspark_gitlab.enabled and (not gitlab_root_password_file.stat.exists or root_password_sha256.stat.checksum != gitlab_root_password_hash.stdout)
+  changed_when: true
+  notify:
+    - restart_gitlab
+    - change_gitlab_root_password
+
 - name: Generate Gitlab config
   template:
     src: templates/gitlab.rb.j2

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -43,7 +43,7 @@
       - name: allspark
     labels:
       "heritage": "allspark"
-    notify:
-      - reconfigure_gitlab
-      - migrate_gitlab
-      - change_gitlab_root_password
+  notify:
+    - reconfigure_gitlab
+    - migrate_gitlab
+    - change_gitlab_root_password

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Load Gitlab root password hash
   command: "cat {{ allspark_root_directory }}/data/gitlab/root_password_hash.txt"
   changed_when: false
-  when: gitlab_root_password_file.stat.exists
+  when: allspark_gitlab.enabled and gitlab_root_password_file.stat.exists
   register: gitlab_root_password_hash
 
 - name: Gitlab root password hash

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -46,4 +46,3 @@
   notify:
     - reconfigure_gitlab
     - migrate_gitlab
-    - change_gitlab_root_password

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -6,12 +6,16 @@
 - name: Generate runner token
   shell: "echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c26) > {{ allspark_root_directory}}/data/secrets/gitlab_runner_registration_token.txt"
   when: allspark_gitlab.enabled and not gitlab_runner_registration_token_file.stat.exists
+  notify:
+    - reconfigure_gitlab
 
 - name: Generate Gitlab config
   template:
     src: templates/gitlab.rb.j2
     dest: "{{ allspark_root_directory }}/config/gitlab.rb"
   when: allspark_gitlab.enabled
+  notify:
+    - reconfigure_gitlab
 
 - name: Create Gitlab volumes
   docker_volume:
@@ -39,3 +43,7 @@
       - name: allspark
     labels:
       "heritage": "allspark"
+    notify:
+      - reconfigure_gitlab
+      - migrate_gitlab
+      - change_gitlab_root_password


### PR DESCRIPTION
### Current behaviour

- Gitlab does not change root password after initial setup (via the `gitlab.rb` file)
- Upon version upgrade, the container state is invalid as migrations haven't ran. The web interface answer with an error code `500` to every HTTP request.

---
### Expected behaviour

- Root password gets updated if the `{{ allspark_root_directory }}/data/secrets/admin_password.txt` file changes.
- Migration are ran when the gitlab container changes.

---
### Modifications

- [x] Update password only if root password hash changes
- [x] Run rake migrations if the container changes.

---
### Related issues

None

---
### Status

- [x] Implementation
- [x] Test coverage
