### PR TITLE
hotfix(removed_duplicate_volumerize_conf)

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -53,9 +53,6 @@ allspark_jenkins:
 allspark_sonarqube:
   enabled: false
 
-allspark_backup:
-  image: blacklabelops/volumerize
-
 allspark_mattermost:
   enabled: true
 


### PR DESCRIPTION
### Current behaviour

The field `allspark_backup.image` exists in the group_vars, but isn't referenced anywhere else in the project. This field is therefore misleading, as an user customizing it won't see any effect on the applicance.

---
### Expected behaviour

No relicates from previous versions in the configuration.

---
### Status

- [x] Implementation
- [x] Test coverage