### PR TITLE
Feature/docker registry

### DIFF
--- a/docs/nav/usage.md
+++ b/docs/nav/usage.md
@@ -1,0 +1,34 @@
+# Usage
+
+## Continuous Integration / Deployment
+---
+
+### Docker registry
+
+When the option `allspark_docker_registry` is enabled, the stack will come with a
+local Docker registry. This registry is only exposed on the host and the `allspark`
+Docker network, in order to make it unavailable to an exernal user, but usable from
+the continuous integration tools.
+
+> Upload an image to the registry:
+
+```sh
+  # Suppose your image is named "myimage:latest"
+
+  # Save the image on your local machine
+  docker save -o img.tar.gz myimage:latest
+
+  AS_USER="allspark"
+  AS_HOST="allspark.localhost"
+
+  # Upload the image to the Allspark host
+  scp img.tar.gz $AS_USER@$AS_HOST:/tmp/img.tar.gz
+  # Load the image in the Docker daemon
+  ssh $AS_USER@$AS_HOST "docker load -i /tmp/img.tar.gz && rm /tmp/img.tar.gz"
+  # Tag this image to push it to the local registry
+  ssh $AS_USER@$AS_HOST "docker tag myimage:latest localhost:5000/myimage:latest"
+  # Push the image
+  ssh $AS_USER@$AS_HOST "docker push localhost:5000/myimage:latest"
+```
+
+You can later use the `localhost:5000/myimage:latest` from the host and continuous integration systems (i.e: Gitlab CI / Jenkins).

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -62,6 +62,9 @@ allspark_mattermost:
 allspark_portainer:
   enabled: true
 
+allspark_docker_registry:
+  enabled: false
+
 ### Release configuration
 # Should not be here
 allspark_release_tmp_directory: /opt/allspark/release

--- a/install.yml
+++ b/install.yml
@@ -7,6 +7,7 @@
     - { role: download, tags: [ "download", "prepare" ] }
     - network
     - haproxy
+    - registry
     - ldap
     - utils
     - monitoring

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Index: index.md
   - Install: install.md
   - Configuration: configuration.md
+  - Usage: usage.md
   - Roadmap: roadmap.md
   - Architecture: architecture.md
   - Operation: operation.md

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -20,6 +20,7 @@ volumerize_image: blacklabelops/volumerize
 mattermost_image: mattermost/mattermost-prod-app
 mattermost_postgresql_image: postgres
 prometheus_alertmanager_image: prom/alertmanager
+registry_image: library/registry
 
 # Tags
 gitlab_tag: latest
@@ -45,6 +46,7 @@ volumerize_tag: latest
 mattermost_tag: latest
 mattermost_postgresql_tag: latest
 prometheus_alertmanager_tag: latest
+registry_tag: latest
 
 # Downloads
 downloads:
@@ -132,6 +134,10 @@ downloads:
     enabled: "{{ allspark_monitoring.enabled }}"
     image: "{{ prometheus_alertmanager_image }}"
     tag: "{{ prometheus_alertmanager_tag }}"
+  registry:
+    enabled: "{{ allspark_docker_registry.enabled }}"
+    image: "{{ registry_image }}"
+    tag: "{{ registry_tag }}"
 
 # Misc
 

--- a/roles/registry/tasks/main.yml
+++ b/roles/registry/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Create Prometheus volume
+  docker_volume:
+    name: "allspark_registry"
+  when: allspark_docker_registry.enabled
+
+- name: Docker registry
+  docker_container:
+    name: registry
+    image: "{{ downloads.registry.image }}:{{ downloads.registry.tag }}"
+    state: "{{ allspark_docker_registry.enabled and 'started' or 'absent'}}"
+    purge_networks: true
+    networks:
+      - name: allspark
+    env:
+      REGISTRY_HTTP_ADDR: "0.0.0.0:5000"
+    published_ports:
+      - 127.0.0.1:5000:5000
+    volumes:
+      - allspark_registry:/var/lib/registry
+    labels:
+      "heritage": "allspark"
+    restart_policy: always

--- a/roles/registry/tasks/main.yml
+++ b/roles/registry/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Create Prometheus volume
+- name: Docker registry volume
   docker_volume:
     name: "allspark_registry"
   when: allspark_docker_registry.enabled


### PR DESCRIPTION
### Current behaviour

Nothing to store Docker images on the stack.
It is required to build against local images on Jenkins and Gitlab-CI, especially on air-gaped systems where the official registries won't be reachable. A workaround is to push the image to a local docker registry and use them as `localhost:5000/myimage`.

---
### Expected behaviour

Docker registry available from
- Host machine
- Docker containers on the `allspark` network

---
### Modifications

- [x] Deployed Docker registry
- [x] Restricted access to host
- [x] Jenkins / Gitlab-CI mount the host socket to use docker, therefore the registry is available from one of these containers at `localhost:5000` (since the resolution is made by Docker on the host)

---
### Status

- [x] Implementation
- [x] Test coverage
- [x] Documentation
