### PR TITLE
hotfix(removed_interactive_gitlab_exec)

### DIFF
--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -4,7 +4,7 @@
 
 - name: reconfigure_gitlab
   command: >-
-    docker exec -it gitlab bash -c '
+    docker exec gitlab bash -c '
     set -xe;
     gitlab-ctl reconfigure;
     '
@@ -15,7 +15,7 @@
 
 - name: migrate_gitlab
   command: >-
-    docker exec -it gitlab bash -c '
+    docker exec gitlab bash -c '
     set -xe;
     gitlab-rake db:migrate;
     '
@@ -26,7 +26,7 @@
 
 - name: change_gitlab_root_password
   command: |
-    docker exec -it gitlab bash -c '
+    docker exec gitlab bash -c '
     set -xe;
     echo "
       user = User.where(id: 1).first;


### PR DESCRIPTION
### Current behaviour

> Describe here the observed behaviour of the software.
`gitlab-ctl reconfigure` yields the following error on a Centos7 production system : 
```
The input device is not a tty
```

---
### Expected behaviour

> Describe here what you expected the software to do instead.

Handler run successfully

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

- [x] removed interactive mode and pseudo TTY allocation on handlers

### Status

- [x] Implementation
- [ ] Test coverage
